### PR TITLE
Harmonize Constructors of SimpleAcLoadFlow and SimpleDcLoadFlow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /cgmes-dl/target
 /cgmes-dl/cgmes-dl-conversion/target/
 /cgmes-dl/cgmes-iidm-extensions/target/
-/loadflow/simple-loadflow/target/
+/simple-loadflow/target/
 /substation-diagram/substation-diagram-core/target/
 /substation-diagram/substation-diagram-cgmes/target/
 /substation-diagram/substation-diagram-util/target/

--- a/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlow.java
+++ b/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlow.java
@@ -35,13 +35,18 @@ public class SimpleAcLoadFlow implements LoadFlow {
 
     private final MatrixFactory matrixFactory;
 
+    public SimpleAcLoadFlow(Network network) {
+        this.network = Objects.requireNonNull(network);
+        this.matrixFactory = new SparseMatrixFactory();
+    }
+
     public SimpleAcLoadFlow(Network network, MatrixFactory matrixFactory) {
         this.network = Objects.requireNonNull(network);
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
     }
 
     public static SimpleAcLoadFlow create(Network network) {
-        return new SimpleAcLoadFlow(network, new SparseMatrixFactory());
+        return new SimpleAcLoadFlow(network);
     }
 
     @Override

--- a/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlowFactory.java
+++ b/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlowFactory.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.loadflow.simple.dc;
+package com.powsybl.loadflow.simple.ac;
 
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
@@ -18,20 +18,20 @@ import java.util.Objects;
 /**
  * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
  */
-public class SimpleDcLoadFlowFactory implements LoadFlowFactory {
+public class SimpleAcLoadFlowFactory implements LoadFlowFactory {
 
     private final MatrixFactory matrixFactory;
 
-    public SimpleDcLoadFlowFactory() {
+    public SimpleAcLoadFlowFactory() {
         this(new SparseMatrixFactory());
     }
 
-    public SimpleDcLoadFlowFactory(MatrixFactory matrixFactory) {
+    public SimpleAcLoadFlowFactory(MatrixFactory matrixFactory) {
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
     }
 
     @Override
     public LoadFlow create(Network network, ComputationManager computationManager, int i) {
-        return new SimpleDcLoadFlow(network, matrixFactory);
+        return new SimpleAcLoadFlow(network, matrixFactory);
     }
 }

--- a/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlow.java
+++ b/simple-loadflow/src/main/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlow.java
@@ -15,10 +15,10 @@ import com.powsybl.loadflow.LoadFlowResultImpl;
 import com.powsybl.loadflow.simple.dc.equations.DcEquationSystem;
 import com.powsybl.loadflow.simple.equations.EquationSystem;
 import com.powsybl.loadflow.simple.network.NetworkContext;
-import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.math.matrix.LUDecomposition;
 import com.powsybl.math.matrix.Matrix;
 import com.powsybl.math.matrix.MatrixFactory;
+import com.powsybl.math.matrix.SparseMatrixFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,12 +51,16 @@ public class SimpleDcLoadFlow implements LoadFlow {
     private final MatrixFactory matrixFactory;
 
     public SimpleDcLoadFlow(Network network) {
-        this(network, new DenseMatrixFactory());
+        this(network, new SparseMatrixFactory());
     }
 
     public SimpleDcLoadFlow(Network network, MatrixFactory matrixFactory) {
         this.network = Objects.requireNonNull(network);
         this.matrixFactory = Objects.requireNonNull(matrixFactory);
+    }
+
+    public static SimpleDcLoadFlow create(Network network) {
+        return new SimpleDcLoadFlow(network);
     }
 
     private static void balance(NetworkContext networkContext) {
@@ -122,7 +126,7 @@ public class SimpleDcLoadFlow implements LoadFlow {
 
     @Override
     public String getName() {
-        return "simple-dc-loadflow";
+        return "Simple DC loadflow";
     }
 
     @Override

--- a/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlowTest.java
+++ b/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/ac/SimpleAcLoadFlowTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.loadflow.simple.ac;
 
 import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.math.matrix.MatrixFactory;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,8 +23,40 @@ public class SimpleAcLoadFlowTest {
     public void metaInfoTest() {
         Network network = Mockito.mock(Network.class);
         MatrixFactory matrixFactory = Mockito.mock(MatrixFactory.class);
-        SimpleAcLoadFlow loadFlow = new SimpleAcLoadFlow(network, matrixFactory);
+        LoadFlow loadFlow = new SimpleAcLoadFlowFactory(matrixFactory).create(network, null, 0);
+        assertTrue(loadFlow instanceof SimpleAcLoadFlow);
         assertEquals("Simple loadflow", loadFlow.getName());
         assertEquals("1.0", loadFlow.getVersion());
+    }
+
+    @Test
+    public void constructionMethodsTest() {
+        Network network = Mockito.mock(Network.class);
+        MatrixFactory matrixFactory = Mockito.mock(MatrixFactory.class);
+
+        // Factory
+        LoadFlow loadFlow1 = new SimpleAcLoadFlowFactory().create(network, null, 0);
+        assertNotNull(loadFlow1);
+        assertTrue(loadFlow1 instanceof SimpleAcLoadFlow);
+
+        // Factory with MatrixFactory
+        LoadFlow loadFlow2 = new SimpleAcLoadFlowFactory(matrixFactory).create(network, null, 0);
+        assertNotNull(loadFlow2);
+        assertTrue(loadFlow2 instanceof SimpleAcLoadFlow);
+
+        // Constructor with Network
+        LoadFlow loadFlow3 = new SimpleAcLoadFlow(network);
+        assertNotNull(loadFlow3);
+        assertTrue(loadFlow3 instanceof SimpleAcLoadFlow);
+
+        // Constructor with Network and MatrixFactory
+        LoadFlow loadFlow4 = new SimpleAcLoadFlow(network, matrixFactory);
+        assertNotNull(loadFlow4);
+        assertTrue(loadFlow4 instanceof SimpleAcLoadFlow);
+
+        // Static factory method
+        LoadFlow loadFlow5 = SimpleAcLoadFlow.create(network);
+        assertNotNull(loadFlow5);
+        assertTrue(loadFlow5 instanceof SimpleAcLoadFlow);
     }
 }

--- a/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlowTest.java
+++ b/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlowTest.java
@@ -33,7 +33,6 @@ public class SimpleDcLoadFlowTest {
 
     private final MatrixFactory matrixFactory = new DenseMatrixFactory();
 
-
     @Test
     public void metaInfoTest() {
         Network network = Mockito.mock(Network.class);

--- a/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlowTest.java
+++ b/simple-loadflow/src/test/java/com/powsybl/loadflow/simple/dc/SimpleDcLoadFlowTest.java
@@ -18,11 +18,11 @@ import com.powsybl.loadflow.simple.network.FourBusNetworkFactory;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import com.powsybl.math.matrix.MatrixFactory;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.usefultoys.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
@@ -32,6 +32,47 @@ public class SimpleDcLoadFlowTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDcLoadFlowTest.class);
 
     private final MatrixFactory matrixFactory = new DenseMatrixFactory();
+
+
+    @Test
+    public void metaInfoTest() {
+        Network network = Mockito.mock(Network.class);
+        LoadFlow loadFlow = new SimpleDcLoadFlowFactory().create(network, null, 0);
+        assertTrue(loadFlow instanceof SimpleDcLoadFlow);
+        assertEquals("Simple DC loadflow", loadFlow.getName());
+        assertEquals("1.0", loadFlow.getVersion());
+    }
+
+    @Test
+    public void constructionMethodsTest() {
+        Network network = Mockito.mock(Network.class);
+        MatrixFactory matrixFactory = Mockito.mock(MatrixFactory.class);
+
+        // Factory
+        LoadFlow loadFlow1 = new SimpleDcLoadFlowFactory().create(network, null, 0);
+        assertNotNull(loadFlow1);
+        assertTrue(loadFlow1 instanceof SimpleDcLoadFlow);
+
+        // Factory with MatrixFactory
+        LoadFlow loadFlow2 = new SimpleDcLoadFlowFactory(matrixFactory).create(network, null, 0);
+        assertNotNull(loadFlow2);
+        assertTrue(loadFlow2 instanceof SimpleDcLoadFlow);
+
+        // Constructor with Network
+        LoadFlow loadFlow3 = new SimpleDcLoadFlow(network);
+        assertNotNull(loadFlow3);
+        assertTrue(loadFlow3 instanceof SimpleDcLoadFlow);
+
+        // Constructor with Network and MatrixFactory
+        LoadFlow loadFlow4 = new SimpleDcLoadFlow(network, matrixFactory);
+        assertNotNull(loadFlow4);
+        assertTrue(loadFlow4 instanceof SimpleDcLoadFlow);
+
+        // Static factory method
+        LoadFlow loadFlow5 = SimpleDcLoadFlow.create(network);
+        assertNotNull(loadFlow5);
+        assertTrue(loadFlow5 instanceof SimpleDcLoadFlow);
+    }
 
     /**
      * Check behaviour of the load flow for simple manipulations on eurostag example 1 network.


### PR DESCRIPTION
Signed-off-by: Sébastien MURGEY <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature (new constructors)

**What is the current behavior?** *(You can also link to an open issue here)*
Currently, SimpleDcLoadFlow and SimpleAcLoadFlow does not have the same construction methods

**What is the new behavior (if this is a feature change)?**
This PR harmonizes the construction methods for Simple Loadflow in AC and DC for tests.

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
SimpleDcLoadFlow used to be constructed with DenseMatrixFactory by default, whereas now it is SparseMatrixFactory by default.
If one need to use dense matrix in SimpleDcLoadFlow, replace
```
LoadFlow loadflow = new SimpleDcLoadFlow(network);
```
by:
```
LoadFlow loadflow = new SimpleDcLoadFlow(network, new DenseMatrixFactory());
```
or
```
LoadFlowFactory loadflowFactory = new SimpleDcLoadFlowFactory();
```
by:
```
LoadFlowFactory loadflowFactory = new SimpleDcLoadFlowFactory(new DenseMatrixFactory());
```
