### PR TITLE
Add equals method to CountryArea

### DIFF
--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
@@ -229,7 +229,7 @@ public class BalanceComputationImpl implements BalanceComputation {
     private List<String> listNetworkAreaInjectionsViolations(NetworkArea networkArea, Map<NetworkArea, Scalable> networkAreasScalableMap) {
         List<String> listOfViolations = new ArrayList<>();
         if (!networkAreasScalableMap.containsKey(networkArea)) {
-            listOfViolations.add("The " + networkArea + " is not defined in the scalable network areas map");
+            listOfViolations.add("The " + networkArea.getName() + " is not defined in the scalable network areas map");
 
         } else {
             Scalable scalable = networkAreasScalableMap.get(networkArea);

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
@@ -46,4 +46,21 @@ public class CountryArea extends AbstractNetworkArea {
     public String getName() {
         return country.getName();
     }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == this) {
+            return true;
+        }
+        if (!(object instanceof CountryArea)) {
+            return false;
+        }
+        CountryArea countryArea = (CountryArea) object;
+        return country.getName().equals(countryArea.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return country.hashCode();
+    }
 }

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
@@ -135,7 +135,7 @@ public class InputDataValidationTest {
 
         balanceComputation = balanceComputationFactory.create(testNetwork1, networkAreaNetPositionTargetMap, networkAreasScalableMap, loadFlowFactory, computationManager, 1);
         List<String> listOfViolations = ((BalanceComputationImpl) balanceComputation).listInputDataViolations();
-        assertTrue(listOfViolations.contains("The " + countryAreaBE + " is not defined in the scalable network areas map"));
+        assertTrue(listOfViolations.contains("The " + countryAreaBE.getName() + " is not defined in the scalable network areas map"));
         assertTrue(listOfViolations.contains("The scalable of " + countryAreaFR + " doesn't contain injections in network"));
 
         try {

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -111,6 +112,12 @@ public class CountryAreaTest {
         //Test network with HVDCLines
         assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation1().getTerminal().getP(), countryAreaFR.getNetPosition(testNetwork2), 1e-3);
         assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation2().getTerminal().getP(), countryAreaES.getNetPosition(testNetwork2), 1e-3);
+    }
 
+    @Test
+    public void testEquals() {
+        List<CountryArea> countries = Arrays.asList(countryAreaBE, countryAreaES, countryAreaFR);
+        CountryArea countryAreaFr2 = new CountryArea(Country.valueOf("FR"));
+        assertTrue(countries.contains(countryAreaFr2));
     }
 }

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -119,5 +119,7 @@ public class CountryAreaTest {
         List<CountryArea> countries = Arrays.asList(countryAreaBE, countryAreaES, countryAreaFR);
         CountryArea countryAreaFr2 = new CountryArea(Country.valueOf("FR"));
         assertTrue(countries.contains(countryAreaFr2));
+        assertTrue(!countryAreaFR.equals(countryAreaES));
+        assertTrue(countryAreaFR.equals(countryAreaFR));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add feature to compare CountryArea. CountryAreas are equals if contains the same country name.


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
