### PR TITLE
Showing correct inductor in voltageLevel diagram for 3WT

### DIFF
--- a/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/model/Graph.java
+++ b/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/model/Graph.java
@@ -53,7 +53,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -834,16 +833,21 @@ public class Graph {
                 .forEach(t -> {
                     VoltageLevel v = t.getVoltageLevel();
                     if (v != node.getGraph().getVoltageLevel()) {
-                        Optional<ShuntCompensator> s = v.getShuntCompensatorStream().findFirst();
-                        if (s.isPresent()
-                                && s.get().getbPerSection() < 0
-                                && infos.get() == null) {  // inductor found
-                            infos.set(new InfosInductor3WT(s.get().getId(),
-                                    s.get().getName(),
-                                    transformer.getSide(t)));
-                        }
+                        v.getShuntCompensatorStream().forEach(s -> {
+                            Bus connectableBusInductor = s.getTerminal().getBusView().getConnectableBus();
+                            Bus connectableBus3WT = t.getBusView().getConnectableBus();
+                            if (connectableBusInductor == connectableBus3WT) {
+                                if (s.getbPerSection() < 0
+                                        && infos.get() == null) {  // inductor found
+                                    infos.set(new InfosInductor3WT(s.getId(),
+                                            s.getName(),
+                                            transformer.getSide(t)));
+                                }
+                            }
+                        });
                     }
                 });
+
         return infos.get();
     }
 


### PR DESCRIPTION
Changing the search algorithm to retrieve the correct inductor, when drawing a voltageLevel (if the right option is selected) :
The inductor is now the one on the same connectable bus as the 3 winding transformer.

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In case of multiple 3WT and inductors in substation, the same inductor is showed 


**What is the new behavior (if this is a feature change)?**
In case of multiple 3WT and inductors in substation, the correct inductor is now showed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
