### PR TITLE
Correcting shunted cell orientation

### DIFF
--- a/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFinder.java
+++ b/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFinder.java
@@ -6,7 +6,13 @@
  */
 package com.powsybl.substationdiagram.layout;
 
+import com.powsybl.substationdiagram.model.Cell;
+import com.powsybl.substationdiagram.model.ExternCell;
 import com.powsybl.substationdiagram.model.Graph;
+import com.powsybl.substationdiagram.model.Node;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * a PositionFinder determines:
@@ -22,4 +28,14 @@ import com.powsybl.substationdiagram.model.Graph;
 public interface PositionFinder {
 
     void buildLayout(Graph graph);
+
+    default void forceSameOrientationForShuntedCell(Graph graph) {
+        for (Cell cell : graph.getCells().stream()
+                .filter(c -> c.getType() == Cell.CellType.SHUNT).collect(Collectors.toList())) {
+            List<Node> shNodes = cell.getNodes().stream()
+                    .filter(node -> node.getType() == Node.NodeType.SHUNT).collect(Collectors.toList());
+            ((ExternCell) shNodes.get(1).getCell()).setDirection(
+                    ((ExternCell) shNodes.get(0).getCell()).getDirection());
+        }
+    }
 }

--- a/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFree.java
+++ b/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFree.java
@@ -54,7 +54,7 @@ public class PositionFree implements PositionFinder {
 //        initiateFeederPosition(context);
 
         graph.setMaxBusPosition();
-
+        forceSameOrientationForShuntedCell(graph);
     }
 
     private void indexBusPosition(Context context) {

--- a/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFromExtension.java
+++ b/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/layout/PositionFromExtension.java
@@ -60,14 +60,4 @@ public class PositionFromExtension implements PositionFinder {
         graph.getCells().stream().filter(cell -> cell.getType() == Cell.CellType.EXTERN).map(ExternCell.class::cast)
                 .forEach(ExternCell::orderFromFeederOrders);
     }
-
-    private void forceSameOrientationForShuntedCell(Graph graph) {
-        for (Cell cell : graph.getCells().stream()
-                .filter(c -> c.getType() == Cell.CellType.SHUNT).collect(Collectors.toList())) {
-            List<Node> shNodes = cell.getNodes().stream()
-                    .filter(node -> node.getType() == Node.NodeType.SHUNT).collect(Collectors.toList());
-            ((ExternCell) shNodes.get(1).getCell()).setDirection(
-                    ((ExternCell) shNodes.get(0).getCell()).getDirection());
-        }
-    }
 }


### PR DESCRIPTION
Forcing same orientation for shunted cell, on all implementations of
PositionFinder interface : PositionFree and PositionFromExtension

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The extern cells of a shunted cell may have different orientations, in a network where the feeders orientation is not available.


**What is the new behavior (if this is a feature change)?**
The extern cells have now the same orientation


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
