### PR TITLE
Hiding substations in javaFX viewer

### DIFF
--- a/substation-diagram/substation-diagram-view/src/main/java/com/powsybl/substationdiagram/view/app/SubstationDiagramViewer.java
+++ b/substation-diagram/substation-diagram-view/src/main/java/com/powsybl/substationdiagram/view/app/SubstationDiagramViewer.java
@@ -186,6 +186,8 @@ public class SubstationDiagramViewer extends Application {
 
     private final CheckBox showNames = new CheckBox("Show names");
 
+    private final CheckBox hideSubstations = new CheckBox("Hide substations");
+
     private final ComboBox<String> diagramNamesComboBox = new ComboBox<>();
 
     private class ContainerDiagramPane extends BorderPane {
@@ -746,6 +748,12 @@ public class SubstationDiagramViewer extends Application {
             substationsTree.refresh();
             refreshDiagram();
         });
+
+        hideSubstations.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            initSubstationsTree();
+            substationsTree.refresh();
+        });
+
         filterInput.textProperty().addListener(obs ->
             initSubstationsTree()
         );
@@ -779,8 +787,9 @@ public class SubstationDiagramViewer extends Application {
         voltageLevelToolBar.setVgap(5);
         voltageLevelToolBar.setPadding(new Insets(5, 5, 5, 5));
         voltageLevelToolBar.add(showNames, 0, 0, 2, 1);
-        voltageLevelToolBar.add(filterLabel, 0, 1);
-        voltageLevelToolBar.add(filterInput, 1, 1);
+        voltageLevelToolBar.add(hideSubstations, 0, 1, 2, 1);
+        voltageLevelToolBar.add(filterLabel, 0, 2);
+        voltageLevelToolBar.add(filterInput, 1, 2);
         ColumnConstraints c0 = new ColumnConstraints();
         ColumnConstraints c1 = new ColumnConstraints();
         c1.setHgrow(Priority.ALWAYS);
@@ -925,7 +934,7 @@ public class SubstationDiagramViewer extends Application {
                 vItem.setSelected(true);
             }
 
-            if (firstVL) {
+            if (firstVL && !hideSubstations.isSelected()) {
                 sItem = new CheckBoxTreeItem<>(s);
                 sItem.setIndependent(true);
                 sItem.setExpanded(true);
@@ -939,7 +948,13 @@ public class SubstationDiagramViewer extends Application {
             }
 
             firstVL = false;
-            sItem.getChildren().add(vItem);
+
+            if (sItem != null) {
+                sItem.getChildren().add(vItem);
+            } else {
+                rootItem.getChildren().add(vItem);
+            }
+
             vItem.selectedProperty().addListener((obs, oldVal, newVal) ->
                     checkVoltageLevel(v, newVal));
         }


### PR DESCRIPTION
Add an option to hide the substations in the tree displayed on the left part of the window

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
'#140'



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
