### PR TITLE
Avoid svg components duplication #44 (#160)

### DIFF
--- a/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/svg/DefaultSVGWriter.java
+++ b/substation-diagram/substation-diagram-core/src/main/java/com/powsybl/substationdiagram/svg/DefaultSVGWriter.java
@@ -152,7 +152,7 @@ public class DefaultSVGWriter implements SVGWriter {
         globalStyle.ifPresent(graphStyle::append);
         graphStyle.append(componentLibrary.getStyleSheet());
 
-        List<String> listUsedComponentSVG = new ArrayList<>();
+        Set<String> listUsedComponentSVG = new HashSet<>();
 
         graph.getNodes().forEach(n -> {
             Optional<String> nodeStyle = styleProvider.getNodeStyle(n, layoutParameters.isAvoidSVGComponentsDuplication());
@@ -274,7 +274,7 @@ public class DefaultSVGWriter implements SVGWriter {
         Document document = domImpl.createDocument("http://www.w3.org/2000/svg", "svg", null);
         Element style = document.createElement("style");
 
-        List<String> listUsedComponentSVG = new ArrayList<>();
+        Set<String> listUsedComponentSVG = new HashSet<>();
 
         StringBuilder graphStyle = new StringBuilder();
         for (Graph vlGraph : graph.getNodes()) {
@@ -1139,7 +1139,7 @@ public class DefaultSVGWriter implements SVGWriter {
     /**
      * Creation of the defs area for the SVG components
      */
-    protected void createDefsSVGComponents(Document document, List<String> listUsedComponentSVG) {
+    protected void createDefsSVGComponents(Document document, Set<String> listUsedComponentSVG) {
         if (layoutParameters.isAvoidSVGComponentsDuplication()) {
             Element defs = document.createElement("defs");
 

--- a/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
+++ b/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
@@ -29,11 +29,6 @@
 .PHASE_SHIFT_TRANSFORMER {stroke:rgb(0,0,255);stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;}
 ]]></style>
     <defs>
-        <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
         <g id="GENERATOR">
     <circle r="6" cx="6" cy="6"/>
     <path d="M6,6 A 6 20 0 0 0 0,6"/>
@@ -44,30 +39,8 @@
     <line y2="9" x1="0" x2="16" y1="0"/>
     <line y2="9" x1="16" x2="0" y1="0"/>
 </g>
-        <g id="GENERATOR">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 20 0 0 0 0,6"/>
-    <path d="M6,6 A 6 20 0 0 0 12,6"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
+        <g id="NODE">
+    <circle r="4" cx="4" cy="4"/>
 </g>
         <g id="DISCONNECTOR">
     <g class="closed" id="DISCONNECTOR-closed">
@@ -77,359 +50,30 @@
     <g class="open" id="DISCONNECTOR-open">
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
 </g>
         <g id="INDUCTOR">
     <path d="M5,5 A 5 20 0 0 0 0,5"/>
     <path d="M10,5 A 5 20 0 0 0 5,5"/>
     <path d="M15,5 A 5 20 0 0 0 10,5"/>
 </g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
-</g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
+        <g id="TWO_WINDINGS_TRANSFORMER">
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
 </g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
+        <g id="BREAKER">
+    <g class="closed" id="BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
 </g>
         <g id="ARROW">
      <g class="arrow-up" id="ARROW-arrow-up">

--- a/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
+++ b/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
@@ -29,31 +29,18 @@
 .PHASE_SHIFT_TRANSFORMER {stroke:rgb(0,0,255);stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;}
 ]]></style>
     <defs>
-        <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
         <g id="GENERATOR">
     <circle r="6" cx="6" cy="6"/>
     <path d="M6,6 A 6 20 0 0 0 0,6"/>
     <path d="M6,6 A 6 20 0 0 0 12,6"/>
 </g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
+        <g id="LOAD">
+    <rect height="9" width="16"/>
+    <line y2="9" x1="0" x2="16" y1="0"/>
+    <line y2="9" x1="16" x2="0" y1="0"/>
 </g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
+        <g id="NODE">
+    <circle r="4" cx="4" cy="4"/>
 </g>
         <g id="DISCONNECTOR">
     <g class="closed" id="DISCONNECTOR-closed">
@@ -63,259 +50,30 @@
     <g class="open" id="DISCONNECTOR-open">
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
 </g>
         <g id="INDUCTOR">
     <path d="M5,5 A 5 20 0 0 0 0,5"/>
     <path d="M10,5 A 5 20 0 0 0 5,5"/>
     <path d="M15,5 A 5 20 0 0 0 10,5"/>
 </g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
-</g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
+        <g id="TWO_WINDINGS_TRANSFORMER">
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
 </g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
+        <g id="BREAKER">
+    <g class="closed" id="BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
 </g>
         <g id="ARROW">
      <g class="arrow-up" id="ARROW-arrow-up">

--- a/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
+++ b/substation-diagram/substation-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
@@ -34,19 +34,8 @@
     <line y2="9" x1="0" x2="16" y1="0"/>
     <line y2="9" x1="16" x2="0" y1="0"/>
 </g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
-</g>
-        <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
-</g>
-        <g id="INDUCTOR">
-    <path d="M5,5 A 5 20 0 0 0 0,5"/>
-    <path d="M10,5 A 5 20 0 0 0 5,5"/>
-    <path d="M15,5 A 5 20 0 0 0 10,5"/>
+        <g id="NODE">
+    <circle r="4" cx="4" cy="4"/>
 </g>
         <g id="CAPACITOR">
     <line y2="3" x1="6" x2="6" y1="0"/>
@@ -63,187 +52,29 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
+        <g id="INDUCTOR">
+    <path d="M5,5 A 5 20 0 0 0 0,5"/>
+    <path d="M10,5 A 5 20 0 0 0 5,5"/>
+    <path d="M15,5 A 5 20 0 0 0 10,5"/>
 </g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
+        <g id="TWO_WINDINGS_TRANSFORMER">
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
+    <circle r="4" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
     <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
 </g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
-</g>
-        <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
-    <circle r="4" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="7" cy="8"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g id="NODE">
-    <circle r="4" cx="4" cy="4"/>
+        <g id="BREAKER">
+    <g class="closed" id="BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
 </g>
         <g id="ARROW">
      <g class="arrow-up" id="ARROW-arrow-up">


### PR DESCRIPTION
Correction in the defs section generation when using the parameter
avoidSVGComponentDuplication

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
