### PR TITLE
fixes cgmes-dl sparql queries, to cover more cim namings (LOADS)

### DIFF
--- a/cgmes-dl/cgmes-dl-conversion/src/main/resources/CGMES-DL.sparql
+++ b/cgmes-dl/cgmes-dl-conversion/src/main/resources/CGMES-DL.sparql
@@ -136,7 +136,7 @@ SELECT ?identifiedObject ?name ?x ?y ?seq ?rotation ?diagramName
     ?identifiedObject
         a ?type ;
         cim:IdentifiedObject.name ?name .
-    VALUES ?type { cim:EnergyConsumer cim:AsynchronousMachine } .
+    VALUES ?type { cim:EnergyConsumer cim:AsynchronousMachine cim:ConformLoad cim:NonConformLoad } .
     ?diagramObjectPoint
         a cim:DiagramObjectPoint ;
         cim:DiagramObjectPoint.DiagramObject ?diagramObject ;


### PR DESCRIPTION
Signed-off-by: Christian Biasuzzi <christian.biasuzzi@techrain.eu>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

helps fixing parts of the problem described in #193 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

bug fix:  during CGMES-DL import, identifies correctly more components by their CGMES names

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
