### PR TITLE
Fix balance adjustment algorithm

### DIFF
--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputation.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputation.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
  * Balance computation feature interface.
  * Asynchronous computation is foreseen
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public interface BalanceComputation {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationFactory.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationFactory.java
@@ -17,7 +17,7 @@ import java.util.Map;
 /**
  * Balance computation factory interface
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public interface BalanceComputationFactory {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationFactoryImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationFactoryImpl.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 /**
  * Balance computation factory to create <code>BalanceComputationImpl</code> class
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationFactoryImpl implements BalanceComputationFactory {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
@@ -14,7 +14,6 @@ import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.loadflow.LoadFlow;
-import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +103,7 @@ public class BalanceComputationImpl implements BalanceComputation {
             }
 
             // Step 3: compute Loadflow
-            LoadFlowResult loadFlowResult = loadFlowRunner.run(network, workingVariantCopyId, computationManager, new LoadFlowParameters());
+            LoadFlowResult loadFlowResult = loadFlowRunner.run(network, workingVariantCopyId, computationManager, parameters.getLoadFlowParameters());
             if (!loadFlowResult.isOk()) {
                 LOGGER.error("Loadflow on network {} does not converge", network.getId());
                 result = new BalanceComputationResult(BalanceComputationResult.Status.FAILED, iterationCounter);

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  * </ul>
  * </p>
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationImpl implements BalanceComputation {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationParameters.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationParameters.java
@@ -6,11 +6,15 @@
  */
 package com.powsybl.balances_adjustment.balance_computation;
 
+import com.powsybl.loadflow.LoadFlowParameters;
+
 /**
  * parameters for balance computation.
  * @author Ameni Walha <ameni.walha at rte-france.com>
  */
 public class BalanceComputationParameters {
+
+    private final LoadFlowParameters loadFlowParameters;
 
     /**
      * Threshold for comparing net positions (given in MW).
@@ -32,7 +36,7 @@ public class BalanceComputationParameters {
      * Constructor with default parameters
      */
     public BalanceComputationParameters() {
-        this(DEFAULT_THRESHOLD_NETPOSITION, DEFAULT_MAX_NUMBER_ITERATIONS);
+        this(DEFAULT_THRESHOLD_NETPOSITION, DEFAULT_MAX_NUMBER_ITERATIONS, new LoadFlowParameters());
     }
 
     /**
@@ -40,9 +44,14 @@ public class BalanceComputationParameters {
      * @param threshold Threshold for comparing net positions (given in MW)
      * @param max Maximum iteration number for balances adjustment
      */
-    public BalanceComputationParameters(double threshold, int max) {
+    public BalanceComputationParameters(double threshold, int max, LoadFlowParameters loadFlowParameters) {
         this.thresholdNetPosition = threshold;
         this.maxNumberIterations = max;
+        this.loadFlowParameters = loadFlowParameters;
+    }
+
+    public LoadFlowParameters getLoadFlowParameters() {
+        return loadFlowParameters;
     }
 
     public double getThresholdNetPosition() {

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationParameters.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationParameters.java
@@ -10,7 +10,7 @@ import com.powsybl.loadflow.LoadFlowParameters;
 
 /**
  * parameters for balance computation.
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationParameters {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationResult.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationResult.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationResult {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/AbstractNetworkArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/AbstractNetworkArea.java
@@ -73,7 +73,10 @@ public abstract class AbstractNetworkArea implements NetworkArea {
     public double getNetPosition(Network network) {
         double netPosition = 0;
         for (BorderDevice b : this.getBorderDevices(network)) {
-            netPosition += b.getLeavingFlow(network, this);
+            double flow = b.getLeavingFlow(network, this);
+            if (!Double.isNaN(flow)) {
+                netPosition += flow;
+            }
         }
         return  netPosition;
     }

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/AbstractNetworkArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/AbstractNetworkArea.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public abstract class AbstractNetworkArea implements NetworkArea {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderBranch.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderBranch.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * BorderBranch is a Branch (Line or TwoWindingsTransformer) at the border of a NetworkArea
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BorderBranch implements BorderDevice {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderDevice.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderDevice.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.Network;
  * Border devices are a subset of "Branch", "HvdcLine" or "ThreeWindingsTransformer" objects
  * that connect a voltage level of the area to a voltage level that is not part of the area.
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public interface BorderDevice {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderHvdcLine.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderHvdcLine.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.VoltageLevel;
 import java.util.List;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BorderHvdcLine implements  BorderDevice {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderThreeWindingsTransformer.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/BorderThreeWindingsTransformer.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * ThreeWindingsTransformer at the border of a NetworkArea
  *
- *  @author Ameni Walha <ameni.walha at rte-france.com>
+ *  @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BorderThreeWindingsTransformer implements  BorderDevice {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class CountryArea extends AbstractNetworkArea {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkArea.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * NetworkArea is defined as a list of participating voltage levels and a list of border devices.
  *
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public interface NetworkArea {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/VoltageLevelsArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/VoltageLevelsArea.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class VoltageLevelsArea extends AbstractNetworkArea {
 

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/VoltageLevelsArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/VoltageLevelsArea.java
@@ -9,16 +9,20 @@ package com.powsybl.balances_adjustment.util;
 import com.powsybl.iidm.network.*;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Ameni Walha <ameni.walha at rte-france.com>
  */
 public class VoltageLevelsArea extends AbstractNetworkArea {
 
+    private final String name;
+
     private final List<VoltageLevel> areaVoltageLevels;
 
-    public VoltageLevelsArea(List<VoltageLevel> areaVoltageLevels) {
-        this.areaVoltageLevels = areaVoltageLevels;
+    public VoltageLevelsArea(String name, List<VoltageLevel> areaVoltageLevels) {
+        this.name = Objects.requireNonNull(name);
+        this.areaVoltageLevels = Objects.requireNonNull(areaVoltageLevels);
     }
 
     @Override
@@ -28,12 +32,6 @@ public class VoltageLevelsArea extends AbstractNetworkArea {
 
     @Override
     public String getName() {
-        StringBuilder sbld = new StringBuilder("VoltageLevelsArea{ ");
-        for (VoltageLevel v : areaVoltageLevels) {
-            sbld.append(v.getName());
-            sbld.append(", ");
-        }
-        sbld.append("}");
-        return sbld.toString();
+        return name;
     }
 }

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationImplDcTest {
     private Network testNetwork1;

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
@@ -16,6 +16,7 @@ import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlow;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import org.junit.Before;
@@ -53,6 +54,10 @@ public class BalanceComputationImplDcTest {
         computationManager = LocalComputationManager.getDefault();
 
         parameters = new BalanceComputationParameters();
+        OpenLoadFlowParameters openLoadFlowParameters = new OpenLoadFlowParameters();
+        openLoadFlowParameters.setDc(true);
+        parameters.getLoadFlowParameters().addExtension(OpenLoadFlowParameters.class, openLoadFlowParameters);
+
         balanceComputationFactory = new BalanceComputationFactoryImpl();
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
@@ -16,7 +16,7 @@ import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlow;
-import com.powsybl.loadflow.open.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import org.junit.Before;
 import org.junit.Test;

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -15,6 +15,7 @@ import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.*;
 import com.powsybl.loadflow.*;
+import com.powsybl.openloadflow.OpenLoadFlowParameters;
 import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import org.junit.Before;
@@ -64,6 +65,10 @@ public class BalanceComputationSimpleDcTest {
         computationManager = LocalComputationManager.getDefault();
 
         parameters = new BalanceComputationParameters();
+        OpenLoadFlowParameters openLoadFlowParameters = new OpenLoadFlowParameters();
+        openLoadFlowParameters.setDc(true);
+        parameters.getLoadFlowParameters().addExtension(OpenLoadFlowParameters.class, openLoadFlowParameters);
+
         balanceComputationFactory = new BalanceComputationFactoryImpl();
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -105,8 +105,8 @@ public class BalanceComputationSimpleDcTest {
     @Test
     public void testBalancedNetworkMockito() {
         networkAreaNetPositionTargetMap = new HashMap<>();
-        networkAreaNetPositionTargetMap.put(countryAreaFR, 1200.);
-        networkAreaNetPositionTargetMap.put(countryAreaBE, -1200.);
+        networkAreaNetPositionTargetMap.put(countryAreaFR, 1199.);
+        networkAreaNetPositionTargetMap.put(countryAreaBE, -1199.);
 
         LoadFlowProvider loadFlowProviderMock = new LoadFlowProvider() {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -15,7 +15,7 @@ import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.*;
 import com.powsybl.loadflow.*;
-import com.powsybl.loadflow.open.OpenLoadFlowProvider;
+import com.powsybl.openloadflow.OpenLoadFlowProvider;
 import com.powsybl.math.matrix.DenseMatrixFactory;
 import org.junit.Before;
 import org.junit.Test;

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BalanceComputationSimpleDcTest {
     private Network simpleNetwork;

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
@@ -106,7 +106,7 @@ public class InputDataValidationTest {
         networkAreaNetPositionTargetMap = new HashMap<>();
         networkAreaNetPositionTargetMap.put(countryAreaNotFound, 0.);
 
-        NetworkArea networkAreaTest = new VoltageLevelsArea(Arrays.asList(testNetwork2.getVoltageLevel("vlFr1A"), testNetwork1.getVoltageLevel("FFR3AA1")));
+        NetworkArea networkAreaTest = new VoltageLevelsArea("Area", Arrays.asList(testNetwork2.getVoltageLevel("vlFr1A"), testNetwork1.getVoltageLevel("FFR3AA1")));
         networkAreaNetPositionTargetMap.put(networkAreaTest, 0.);
 
         balanceComputation = balanceComputationFactory.create(testNetwork1, networkAreaNetPositionTargetMap, networkAreasScalableMap, loadFlowRunner, computationManager, 1);

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/InputDataValidationTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class InputDataValidationTest {
     private BalanceComputation balanceComputation;

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/BorderDeviceTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/BorderDeviceTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class BorderDeviceTest {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 import static org.junit.Assert.*;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class CountryAreaTest {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class NetworkAreaTest {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaTest.java
@@ -36,7 +36,7 @@ public class NetworkAreaTest {
         List<VoltageLevel> voltageLevels1 = testNetwork1.getVoltageLevelStream().filter(v -> v.getId().equals("FFR1AA1") || v.getId().equals("FFR3AA1"))
                 .collect(Collectors.toList());
 
-        voltageLevelsArea1 = new VoltageLevelsArea(voltageLevels1);
+        voltageLevelsArea1 = new VoltageLevelsArea("Area1", voltageLevels1);
 
         countryAreaFR = new CountryArea(Country.FR);
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkTestFactory.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkTestFactory.java
@@ -8,7 +8,7 @@ package com.powsybl.balances_adjustment.util;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public final class NetworkTestFactory {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/VoltageLevelsAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/VoltageLevelsAreaTest.java
@@ -42,13 +42,13 @@ public class VoltageLevelsAreaTest {
         voltageLevels1 = testNetwork1.getVoltageLevelStream().filter(v -> v.getId().equals("FFR1AA1") || v.getId().equals("DDE3AA1"))
                 .collect(Collectors.toList());
 
-        voltageLevelsArea1 = new VoltageLevelsArea(voltageLevels1);
+        voltageLevelsArea1 = new VoltageLevelsArea("Area1", voltageLevels1);
 
         //test Network with ThreeWindingsTransformer
         voltageLevels2 = testNetwork2.getVoltageLevelStream().filter(v -> v.getId().equals("vlFr1A") || v.getId().equals("vlEs1B"))
                 .collect(Collectors.toList());
 
-        voltageLevelsArea2 = new VoltageLevelsArea(voltageLevels2);
+        voltageLevelsArea2 = new VoltageLevelsArea("Area2", voltageLevels2);
 
     }
 
@@ -61,7 +61,7 @@ public class VoltageLevelsAreaTest {
         assertTrue(checkSameList(voltageLevelsArea1.getAreaVoltageLevels(testNetwork1), voltageLevels1));
         List<VoltageLevel> voltageLevelsTest2 = new ArrayList<>(Arrays.asList(testNetwork2.getVoltageLevel("vlFr1A"), testNetwork2.getVoltageLevel("vlEs1B")));
         assertTrue(checkSameList(voltageLevelsArea2.getAreaVoltageLevels(testNetwork2), voltageLevelsTest2));
-        assertEquals("VoltageLevelsArea{ vlFr1A, vlEs1B, }", voltageLevelsArea2.getName());
+        assertEquals("Area2", voltageLevelsArea2.getName());
     }
 
     @Test

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/VoltageLevelsAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/VoltageLevelsAreaTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 
 /**
- * @author Ameni Walha <ameni.walha at rte-france.com>
+ * @author Ameni Walha {@literal <ameni.walha at rte-france.com>}
  */
 public class VoltageLevelsAreaTest {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix?


**What is the current behavior?** *(You can also link to an open issue here)*
The balance adjustment doesn't work properly on real UCTE cases using Vulcanus net positions. It fails with the following errors:
- P is not in range [Pmin, Pmax]
- P is invalid
- The algorithm don't converge


**What is the new behavior (if this is a feature change)?**
- Fix balance computation by skipping NaN values
- Fix the name of VoltageLevelsArea
- Change a little bit the algorithm

I also change the criteria to stop the iteration. I have also ideas to improve the API and the design, I will create an issue to explain what I have in mind.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
