### PR TITLE
Fix: better way to import svgdotjs

### DIFF
--- a/substation-webviewer/src/App.js
+++ b/substation-webviewer/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import SVG from "@svgdotjs/svg.js/src/svg.js";
+import { SVG } from "@svgdotjs/svg.js";
 import "@svgdotjs/svg.draggable.js";
 import "@svgdotjs/svg.panzoom.js";
 import './App.css';


### PR DESCRIPTION
The previous method broke in another website because the object extended by the
panzoom plugin (added panZoom function to prototype) was not the same as the
object used when calling SVG(): error, no function panZoom() on object. Somehow
when panzoom was extending, the extended object was reported as a plain object
in the console, but when SVG() was called it was the class. Maybe this depends
on the babel version or the webpack version.

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactor


**What is the current behavior?** *(You can also link to an open issue here)*
svgdotjs imported weirdly in webviewer


**What is the new behavior (if this is a feature change)?**
svgdotjs imported correctly in webviewer



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
This was copied in another project and didn't work