### PR TITLE
Remove substation-viewer module from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
 
     <modules>
         <module>cgmes-gl</module>
-        <module>substation-webviewer</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Quick fix.

**What is the current behavior?** *(You can also link to an open issue here)*

The substation-viewer module does not build any more, and make CI fails.
If it's not maintained, we can remove it from CI.
See this discussion about why this fails : https://github.com/facebook/create-react-app/issues/3657 .
React seems to treat warnings as errors in CI environment, there is no way to deactivate specifically this.

**What is the new behavior (if this is a feature change)?**

substation-viewer is removed from parent module and thus from CI.

@jonenst don't hesitate to propose something better :)

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
